### PR TITLE
RFC: Integer variable modeling

### DIFF
--- a/src/lp/dominated_column.jl
+++ b/src/lp/dominated_column.jl
@@ -6,7 +6,7 @@ struct DominatedColumn{T} <: PresolveTransformation{T}
 end
 
 function remove_dominated_column!(ps::PresolveData{T}, j::Int; tol::T=100 * sqrt(eps(T))) where {T}
-    is_continuous(ps.pb0) || error("Dominated column routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Dominated column routine currently only supported for LPs.")
 
     ps.colflag[j] || return nothing
 

--- a/src/lp/dominated_column.jl
+++ b/src/lp/dominated_column.jl
@@ -5,7 +5,9 @@ struct DominatedColumn{T} <: PresolveTransformation{T}
     col::Col{T}  # Column
 end
 
-function remove_dominated_column!(ps::PresolveData{T}, j::Int; tol::T=100*sqrt(eps(T))) where{T}
+function remove_dominated_column!(ps::PresolveData{T}, j::Int; tol::T=100 * sqrt(eps(T))) where {T}
+    is_continuous(ps.pb0) || error("Dominated column routine currently only supported for LPs.")
+
     ps.colflag[j] || return nothing
 
     # Compute implied bounds on reduced cost: `ls ≤ s ≤ us`
@@ -80,7 +82,7 @@ function remove_dominated_column!(ps::PresolveData{T}, j::Int; tol::T=100*sqrt(e
     elseif cj - ls < -tol
         # Reduced cost is always negative => fix to upper bound (or problem is unbounded)
         ub = ps.ucol[j]
-        
+
         if !isfinite(ub)
             # Problem is unbounded
             @debug "Column $j is (upper) unbounded"
@@ -140,7 +142,7 @@ function remove_dominated_column!(ps::PresolveData{T}, j::Int; tol::T=100*sqrt(e
     return nothing
 end
 
-function postsolve!(sol::Solution{T}, op::DominatedColumn{T}) where{T}
+function postsolve!(sol::Solution{T}, op::DominatedColumn{T}) where {T}
     # Primal value
     sol.x[op.j] = op.x
 

--- a/src/lp/empty_column.jl
+++ b/src/lp/empty_column.jl
@@ -5,7 +5,7 @@ struct EmptyColumn{T} <: PresolveTransformation{T}
 end
 
 function remove_empty_column!(ps::PresolveData{T}, j::Int) where {T}
-    is_continuous(ps.pb0) || error("Empty column routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Empty column routine currently only supported for LPs.")
 
     # Sanity check
     (ps.colflag[j] && (ps.nzcol[j] == 0)) || return nothing

--- a/src/lp/empty_column.jl
+++ b/src/lp/empty_column.jl
@@ -4,7 +4,9 @@ struct EmptyColumn{T} <: PresolveTransformation{T}
     s::T  # Reduced cost
 end
 
-function remove_empty_column!(ps::PresolveData{T}, j::Int) where{T}
+function remove_empty_column!(ps::PresolveData{T}, j::Int) where {T}
+    is_continuous(ps.pb0) || error("Empty column routine currently only supported for LPs.")
+
     # Sanity check
     (ps.colflag[j] && (ps.nzcol[j] == 0)) || return nothing
 
@@ -74,7 +76,7 @@ function remove_empty_column!(ps::PresolveData{T}, j::Int) where{T}
             ps.solution.z_primal = ps.solution.z_dual = -T(Inf)
             j_ = ps.new_var_idx[j]
             ps.solution.x[j_] = one(T)
-            
+
             return
         end
     else
@@ -97,7 +99,7 @@ function remove_empty_column!(ps::PresolveData{T}, j::Int) where{T}
     return nothing
 end
 
-function postsolve!(sol::Solution{T}, op::EmptyColumn{T}) where{T}
+function postsolve!(sol::Solution{T}, op::EmptyColumn{T}) where {T}
     sol.x[op.j] = op.x
     sol.s_lower[op.j] = pos_part(op.s)
     sol.s_upper[op.j] = neg_part(op.s)

--- a/src/lp/empty_row.jl
+++ b/src/lp/empty_row.jl
@@ -6,7 +6,9 @@ struct EmptyRow{T} <: PresolveTransformation{T}
     y::T  # dual multiplier
 end
 
-function remove_empty_row!(ps::PresolveData{T}, i::Int) where{T}
+function remove_empty_row!(ps::PresolveData{T}, i::Int) where {T}
+    is_continuous(ps.pb0) || error("Empty row routine currently only supported for LPs.")
+
     # Sanity checks
     (ps.rowflag[i] && ps.nzrow[i] == 0) || return nothing
 
@@ -50,7 +52,7 @@ function remove_empty_row!(ps::PresolveData{T}, i::Int) where{T}
         ps.solution.y_upper .= zero(T)
         ps.solution.s_lower .= zero(T)
         ps.solution.s_upper .= zero(T)
-        
+
         # Farkas ray: y⁺_i = 1 (any > 0 value works)
         ps.solution.primal_status = Sln_Unknown
         ps.solution.dual_status = Sln_InfeasibilityCertificate
@@ -70,7 +72,7 @@ function remove_empty_row!(ps::PresolveData{T}, i::Int) where{T}
     ps.nrow -= 1
 end
 
-function postsolve!(sol::Solution{T}, op::EmptyRow{T}) where{T}
+function postsolve!(sol::Solution{T}, op::EmptyRow{T}) where {T}
     sol.y_lower[op.i] = pos_part(op.y)
     sol.y_upper[op.i] = neg_part(op.y)
     return nothing

--- a/src/lp/empty_row.jl
+++ b/src/lp/empty_row.jl
@@ -7,7 +7,7 @@ struct EmptyRow{T} <: PresolveTransformation{T}
 end
 
 function remove_empty_row!(ps::PresolveData{T}, i::Int) where {T}
-    is_continuous(ps.pb0) || error("Empty row routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Empty row routine currently only supported for LPs.")
 
     # Sanity checks
     (ps.rowflag[i] && ps.nzrow[i] == 0) || return nothing

--- a/src/lp/forcing_row.jl
+++ b/src/lp/forcing_row.jl
@@ -12,7 +12,7 @@ struct DominatedRow{T} <: PresolveTransformation{T}
 end
 
 function remove_forcing_row!(ps::PresolveData{T}, i::Int) where {T}
-    is_continuous(ps.pb0) || error("Forcing row routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Forcing row routine currently only supported for LPs.")
 
     ps.rowflag[i] || return
     ps.nzrow[i] == 1 && return  # skip row singletons

--- a/src/lp/forcing_row.jl
+++ b/src/lp/forcing_row.jl
@@ -11,9 +11,11 @@ struct DominatedRow{T} <: PresolveTransformation{T}
     i::Int  # Row index
 end
 
-function remove_forcing_row!(ps::PresolveData{T}, i::Int) where{T}
+function remove_forcing_row!(ps::PresolveData{T}, i::Int) where {T}
+    is_continuous(ps.pb0) || error("Forcing row routine currently only supported for LPs.")
+
     ps.rowflag[i] || return
-    ps.nzrow[i] == 1 && return  # skip row singletons 
+    ps.nzrow[i] == 1 && return  # skip row singletons
 
     # Implied row bounds
     row = ps.pb0.arows[i]
@@ -89,7 +91,7 @@ function remove_forcing_row!(ps::PresolveData{T}, i::Int) where{T}
                 # ps.nzrow[k] == 0 && remove_empty_row!(ps, k)
                 ps.nzrow[k] == 1 && push!(ps.row_singletons, k)
             end
-            
+
             cj = ps.obj[j]
             push!(cols_, col_)
             push!(xs, xj_)
@@ -151,7 +153,7 @@ function remove_forcing_row!(ps::PresolveData{T}, i::Int) where{T}
                 # ps.nzrow[k] == 0 && remove_empty_row!(ps, k)
                 ps.nzrow[k] == 1 && push!(ps.row_singletons, k)
             end
-            
+
             cj = ps.obj[j]
             push!(cols_, col_)
             push!(xs, xj_)
@@ -175,14 +177,14 @@ function remove_forcing_row!(ps::PresolveData{T}, i::Int) where{T}
     return nothing
 end
 
-function postsolve!(sol::Solution{T}, op::DominatedRow{T}) where{T}
+function postsolve!(sol::Solution{T}, op::DominatedRow{T}) where {T}
     sol.y_lower[op.i] = zero(T)
     sol.y_upper[op.i] = zero(T)
     return nothing
 end
 
 # TODO: postsolve of forcing rows
-function postsolve!(sol::Solution{T}, op::ForcingRow{T}) where{T}
+function postsolve!(sol::Solution{T}, op::ForcingRow{T}) where {T}
 
     # Primal
     for (j, xj) in zip(op.row.nzind, op.xs)

--- a/src/lp/free_column_singleton.jl
+++ b/src/lp/free_column_singleton.jl
@@ -8,7 +8,8 @@ struct FreeColumnSingleton{T} <: PresolveTransformation{T}
     row::Row{T}
 end
 
-function remove_free_column_singleton!(ps::PresolveData{T}, j::Int) where{T}
+function remove_free_column_singleton!(ps::PresolveData{T}, j::Int) where {T}
+    is_continuous(ps.pb0) || error("Free column routine currently only supported for LPs.")
 
     ps.colflag[j] && ps.nzcol[j] == 1 || return nothing  # only column singletons
 
@@ -108,7 +109,7 @@ function remove_free_column_singleton!(ps::PresolveData{T}, j::Int) where{T}
     return nothing
 end
 
-function postsolve!(sol::Solution{T}, op::FreeColumnSingleton{T}) where{T}
+function postsolve!(sol::Solution{T}, op::FreeColumnSingleton{T}) where {T}
     # Dual
     y = op.y
     sol.y_lower[op.i] = pos_part(y)
@@ -122,6 +123,6 @@ function postsolve!(sol::Solution{T}, op::FreeColumnSingleton{T}) where{T}
         sol.x[op.j] -= aik * sol.x[k]
     end
     sol.x[op.j] /= op.aij
-    
+
     return nothing
 end

--- a/src/lp/free_column_singleton.jl
+++ b/src/lp/free_column_singleton.jl
@@ -9,7 +9,7 @@ struct FreeColumnSingleton{T} <: PresolveTransformation{T}
 end
 
 function remove_free_column_singleton!(ps::PresolveData{T}, j::Int) where {T}
-    is_continuous(ps.pb0) || error("Free column routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Free column routine currently only supported for LPs.")
 
     ps.colflag[j] && ps.nzcol[j] == 1 || return nothing  # only column singletons
 

--- a/src/lp/row_singleton.jl
+++ b/src/lp/row_singleton.jl
@@ -7,7 +7,9 @@ struct RowSingleton{T} <: PresolveTransformation{T}
 end
 
 
-function remove_row_singleton!(ps::PresolveData{T}, i::Int) where{T}
+function remove_row_singleton!(ps::PresolveData{T}, i::Int) where {T}
+    is_continuous(ps.pb0) || error("Row singleton routine currently only supported for LPs.")
+
     # Sanity checks
     (ps.rowflag[i] && ps.nzrow[i] == 1) || return nothing
 
@@ -78,7 +80,7 @@ function remove_row_singleton!(ps::PresolveData{T}, i::Int) where{T}
     return nothing
 end
 
-function postsolve!(sol::Solution{T}, op::RowSingleton{T}) where{T}
+function postsolve!(sol::Solution{T}, op::RowSingleton{T}) where {T}
 
     if op.force_lower
         if op.aij > zero(T)

--- a/src/lp/row_singleton.jl
+++ b/src/lp/row_singleton.jl
@@ -8,7 +8,7 @@ end
 
 
 function remove_row_singleton!(ps::PresolveData{T}, i::Int) where {T}
-    is_continuous(ps.pb0) || error("Row singleton routine currently only supported for LPs.")
+    ps.pb0.is_continuous || error("Row singleton routine currently only supported for LPs.")
 
     # Sanity checks
     (ps.rowflag[i] && ps.nzrow[i] == 1) || return nothing

--- a/src/presolve.jl
+++ b/src/presolve.jl
@@ -216,6 +216,7 @@ function extract_reduced_problem!(ps::PresolveData{T}) where {T}
 
     # Extract new columns
     pb.acols = Vector{Col{T}}(undef, pb.nvar)
+    pb.var_types = Vector{VariableType}(undef, pb.nvar)
     jnew = 0
     for (jold, col) in enumerate(ps.pb0.acols)
         ps.colflag[jold] || continue
@@ -238,12 +239,8 @@ function extract_reduced_problem!(ps::PresolveData{T}) where {T}
 
         # Set new column
         pb.acols[jnew] = Col{T}(cind, cval)
+        pb.var_types[jnew] = ps.pb0.var_types[jold]
     end
-
-    # Variable and constraint names
-    # TODO: we don't need these
-    pb.var_names = ps.pb0.var_names[ps.colflag]
-    pb.con_names = ps.pb0.con_names[ps.rowflag]
 
     # Scaling
     rscale = zeros(T, ps.nrow)

--- a/src/problem_data.jl
+++ b/src/problem_data.jl
@@ -57,6 +57,7 @@ mutable struct ProblemData{T}
 
     # Variable types
     var_types::Vector{VariableType}
+    is_continuous::Bool
 
     # Only allow empty problems to be instantiated for now
     ProblemData{T}(pbname::String="") where {T} = new{T}(
@@ -64,7 +65,7 @@ mutable struct ProblemData{T}
         true, T[], zero(T),
         Row{T}[], Col{T}[],
         T[], T[], T[], T[],
-        VariableType[],
+        VariableType[], true,
     )
 end
 
@@ -90,6 +91,7 @@ function Base.empty!(pb::ProblemData{T}) where {T}
     pb.uvar = T[]
 
     pb.var_types = VariableType[]
+    pb.is_continuous = true
 
     return pb
 end
@@ -117,6 +119,9 @@ function load_problem!(pb::ProblemData{T},
     isfinite(obj0) || error("Objective offset $obj0 is not finite")
     nvar == length(lvar) || error("")
     nvar == length(uvar) || error("")
+    if var_types !== nothing
+        nvar == length(var_types) || error("")
+    end
 
     # Copy data
     pb.name = name
@@ -131,8 +136,10 @@ function load_problem!(pb::ProblemData{T},
     pb.uvar = copy(uvar)
     if var_types === nothing
         pb.var_types = fill(CONTINUOUS, nvar)
+        pb.is_continuous = true
     else
         pb.var_types = copy(var_types)
+        pb.is_continuous = all(pb.var_types .== CONTINUOUS)
     end
 
     # Load coefficients
@@ -151,5 +158,3 @@ function load_problem!(pb::ProblemData{T},
 
     return pb
 end
-
-is_continuous(pb::ProblemData) = all(pb.var_types .== CONTINUOUS)

--- a/test/lp/empty_column.jl
+++ b/test/lp/empty_column.jl
@@ -20,7 +20,7 @@ function emtpy_column_tests(T::Type)
 
         MathOptPresolve.load_problem!(pb, "Test",
             true, [c], zero(T),
-            spzeros(T, 0, 1), T[], T[], [l], [u], String[], ["x"]
+            spzeros(T, 0, 1), T[], T[], [l], [u],
         )
         return pb
     end

--- a/test/lp/empty_row.jl
+++ b/test/lp/empty_row.jl
@@ -16,7 +16,6 @@ function empty_row_tests(T::Type)
     MathOptPresolve.load_problem!(pb, "test",
         true, c, zero(T),
         A, T.([-1, 1]), T.([1, 2]), zeros(T, n), fill(T(Inf), n),
-        ["c1", "c2"], ["x", "y", "z"]
     )
 
     ps = MathOptPresolve.PresolveData(pb)
@@ -78,7 +77,6 @@ function test_empty_row_1(T::Type)
     MathOptPresolve.load_problem!(pb, "test",
         true, c, zero(T),
         A, T.([1]), T.([2]), zeros(T, n), fill(T(Inf), n),
-        ["c1"], ["x"]
     )
 
     ps = MathOptPresolve.PresolveData(pb)
@@ -116,7 +114,6 @@ function test_empty_row_2(T::Type)
     MathOptPresolve.load_problem!(pb, "test",
         true, c, zero(T),
         A, T.([-2]), T.([-1]), zeros(T, n), fill(T(Inf), n),
-        ["c1"], ["x"]
     )
 
     ps = MathOptPresolve.PresolveData(pb)

--- a/test/lp/fixed_variable.jl
+++ b/test/lp/fixed_variable.jl
@@ -20,7 +20,6 @@ function test_fixed_variable_with_zeros(T::Type)
         A,
         zeros(T, m), ones(T, m),
         ones(T, n), ones(T, n),
-        ["" for _ in 1:m], ["" for _ in 1:n]
     )
 
     ps = MathOptPresolve.PresolveData(pb)

--- a/test/problem_data.jl
+++ b/test/problem_data.jl
@@ -59,6 +59,8 @@ function run_tests_pbdata(T::Type)
         @test pb.lcon == [T(-Inf), -one(T)]
         @test pb.ucon == [one(T), zero(T)]
 
+        @test pb.var_types == [MathOptPresolve.CONTINUOUS, MathOptPresolve.BINARY]
+
         empty!(pb)
         @test pb.name == ""
         @test iszero(pb.obj0)

--- a/test/problem_data.jl
+++ b/test/problem_data.jl
@@ -13,7 +13,8 @@ function run_tests_pbdata(T::Type)
             s.t.    -∞ ⩽  -x1 +   x2 ⩽ 1
                     -1 ⩽ 2 x1 - 2 x2 ⩽ 0
                     0 ⩽ x1 ⩽ ∞
-                    1 ⩽ x2 ⩽ ∞ =#
+                    1 ⩽ x2 ⩽ ∞
+                    x2 in \{0,1\} =#
 
         MathOptPresolve.load_problem!(
             pb,
@@ -27,8 +28,7 @@ function run_tests_pbdata(T::Type)
             T[1.0, 0.0],
             T[0.0, 1.0],
             T[Inf, Inf],
-            ["row1", "row2"],
-            ["x1", "x2"],
+            MathOptPresolve.VariableType[MathOptPresolve.CONTINUOUS, MathOptPresolve.BINARY],
         )
 
         @test pb.name == "test-filled"
@@ -40,7 +40,6 @@ function run_tests_pbdata(T::Type)
         @test pb.obj == [one(T), 2 * one(T)]
         @test pb.lvar == [zero(T), one(T)]
         @test pb.uvar == [T(Inf), T(Inf)]
-        @test pb.var_names == ["x1", "x2"]
 
         # Check dimensions
         check_problem_size(pb, 2, 2)
@@ -59,9 +58,6 @@ function run_tests_pbdata(T::Type)
         # Check row bounds
         @test pb.lcon == [T(-Inf), -one(T)]
         @test pb.ucon == [one(T), zero(T)]
-        # Check names
-        @test pb.con_names == ["row1", "row2"]
-        @test pb.var_names == ["x1", "x2"]
 
         empty!(pb)
         @test pb.name == ""
@@ -86,8 +82,6 @@ function check_problem_size(pb::MathOptPresolve.ProblemData, ncon::Int, nvar::In
     @test length(pb.lvar) == nvar
     @test length(pb.uvar) == nvar
 
-    @test length(pb.con_names) == ncon
-    @test length(pb.var_names) == nvar
     return nothing
 end
 

--- a/test/problem_data.jl
+++ b/test/problem_data.jl
@@ -60,6 +60,7 @@ function run_tests_pbdata(T::Type)
         @test pb.ucon == [one(T), zero(T)]
 
         @test pb.var_types == [MathOptPresolve.CONTINUOUS, MathOptPresolve.BINARY]
+        @test !pb.is_continuous
 
         empty!(pb)
         @test pb.name == ""


### PR DESCRIPTION
I added a new field to ``ProblemData`` to track the types of variables. At this point, a variable can be continuous, binary, or general integer. This is not yet plugged into anything interesting, and in fact all but one of the LP presolve routines will immediately error in the presence of integer variables. I want to audit things first to make sure that the routines are "safe" for IPs.

Along the way, I ripped out the variable/constraint name fields. They did not seem useful to me, and they made the modeling interface marginally uglier since I wanted to make the "variable type" field optional. I can revert or split this change into a separate PR if desired.

I chose to store the types as a separate field, rather than trying to pack this into the ``Col`` type. I'm open to changing it if desired, though.

(Sorry about the unrelated whitespace changes, VS Code apparently ran a linter in the background).