### PR TITLE
[RFC] Translate empty column rule and reduction to apply! syntax

### DIFF
--- a/docs/src/manual/reductions.md
+++ b/docs/src/manual/reductions.md
@@ -7,5 +7,7 @@ CurrentModule = MathOptPresolve
 ```@docs
 RemoveEmptyRow
 RemoveEmptyRows
+RemoveEmptyColumn
+RemoveEmptyColumns
 FixSingleVariable
 ```

--- a/src/lp/empty_column.jl
+++ b/src/lp/empty_column.jl
@@ -1,10 +1,71 @@
+@doc raw"""
+    RemoveEmptyColumn <: AbstractRule
+
+Eliminate a single column if it is empty, i.e. all coefficients are zero.
+
+## Presolve
+
+If column $j$ is empty, variable $x_{j}$ is fixed to $x_{j}^{*}$ as follows
+
+| $c_{j}$ |        $l_{j}$ |        $u_{j}$ | $x^{*}_{j}$ |
+|--------:|---------------:|---------------:|------------:|
+|    $<0$ |              - | $∈ \mathbb{R}$ |     $u_{j}$ |
+|    $<0$ |              - |           $+∞$ |    $+∞^{†}$ |
+|     $0$ | $∈ \mathbb{R}$ |              - |     $l_{j}$ |
+|     $0$ | $-∞$           | $∈ \mathbb{R}$ |     $u_{j}$ |
+|     $0$ | $-∞$           |           $+∞$ |     $0$     |
+|    $>0$ | $∈ \mathbb{R}$ |              - |     $l_{j}$ |
+|    $>0$ | $-∞$           |              - |    $-∞^{†}$ |
+``^{†}`` problem is dual infeasible
+
+## Dual infeasibility (unboundedness) checks
+
+For a prescribed tolerance $ϵ ≥ 0$, the problem is dual infeasible if
+    column $j$ is empty and either
+1. Variable $j$ has no lower bound, and its objective coefficient is positive,
+    i.e., $l^{c}_{j} = -∞$ and $c_{j} > ϵ$.
+2. column $j$ is empty, has no upper bound, and its objective coefficient is negative,
+    i.e., $l^{c}_{j} = +∞$ and $c_{j} < -ϵ$.
+
+The corresponding unbounded rays (dual infeasibility certificates) are
+1.  $x = -e_{j}$,
+2.  $x = e_{j}$,
+
+where $e_{j}$ is the $j$-th vector of the canonical basis.
+
+## Postsolve
+
+TODO
+
+## Misc
+
+* This is a dual reduction, and it can handle integer variables.
+* This reduction is non-destructive.
+* This reduction does not create any fill-in.
+"""
+struct RemoveEmptyColumn <: AbstractRule
+    j::Int
+end
+
+@doc raw"""
+    EmptyColumn{T} <: AbstractReduction{T}
+
+Column $j$ is empty (all coefficients are zero).
+"""
 struct EmptyColumn{T} <: AbstractReduction{T}
     j::Int  # variable index
     x::T  # Variable value
     s::T  # Reduced cost
 end
 
-function remove_empty_column!(ps::PresolveData{T}, j::Int) where {T}
+function apply!(
+    ps::PresolveData{T},
+    r::RemoveEmptyColumn,
+    config::PresolveOptions{T},
+) where {T}
+    j = r.j
+    ϵ = config.DualTolerance
+
     ps.pb0.is_continuous || error("Empty column routine currently only supported for LPs.")
 
     # Sanity check
@@ -103,5 +164,28 @@ function postsolve!(sol::Solution{T}, op::EmptyColumn{T}) where {T}
     sol.x[op.j] = op.x
     sol.s_lower[op.j] = pos_part(op.s)
     sol.s_upper[op.j] = neg_part(op.s)
+    return nothing
+end
+
+"""
+    RemoveEmptyColumns <: AbstractRule
+
+Remove all empty columns in the problem.
+
+See [`RemoveEmptyColumn`](@ref).
+"""
+struct RemoveEmptyColumns <: AbstractRule end
+
+function apply!(
+    ps::PresolveData{T},
+    ::RemoveEmptyColumns,
+    config::PresolveOptions{T}
+) where {T}
+    for j in 1:ps.pb0.nvar
+        if ps.colflag[j] && (ps.nzcol[j] == 0)
+            apply!(ps, RemoveEmptyColumn(j), config)
+            ps.status == NOT_INFERRED || return nothing
+        end
+    end
     return nothing
 end

--- a/test/lp/empty_column.jl
+++ b/test/lp/empty_column.jl
@@ -1,7 +1,7 @@
-function emtpy_column_tests(T::Type)
+function empty_column_tests(T::Type)
 
     # We test all the following combinations:
-    #= 
+    #=
         min          c * x
         s.t.    lb ≤     x ≤ ub
 
@@ -14,11 +14,12 @@ function emtpy_column_tests(T::Type)
         (-∞, +∞)    | -∞  | +∞  |  0
         ( l,  u)    |  l  |  u  |  l
         ( l, +∞)    |  l  | +∞  |  l
-        ------------------------------ =#
+        ------------------------------
+    =#
     function build_problem(l, u, c)
-        pb = MathOptPresolve.ProblemData{T}()
+        pb = MOP.ProblemData{T}()
 
-        MathOptPresolve.load_problem!(pb, "Test",
+        MOP.load_problem!(pb, "Test",
             true, [c], zero(T),
             spzeros(T, 0, 1), T[], T[], [l], [u],
         )
@@ -32,10 +33,11 @@ function emtpy_column_tests(T::Type)
         @testset "$((l, u, c))" begin
             pb = build_problem(l, u, c)
 
-            ps = MathOptPresolve.PresolveData(pb)
+            ps = MOP.PresolveData(pb)
+            config = MOP.PresolveOptions{T}()
 
             # Remove empty variable
-            MathOptPresolve.remove_empty_column!(ps, 1)
+            MOP.apply!(ps, MOP.RemoveEmptyColumn(1), config)
 
             if c > 0 && !isfinite(l)
                 @test ps.status == MOP.DUAL_INFEASIBLE
@@ -64,7 +66,7 @@ function emtpy_column_tests(T::Type)
                 # Check that operation was recorded correctly
                 @test length(ps.ops) == 1
                 op = ps.ops[1]
-                @test isa(op, MathOptPresolve.EmptyColumn)
+                @test isa(op, MOP.EmptyColumn)
                 @test op.j == 1
             end
         end  # testset
@@ -75,6 +77,6 @@ end
 
 @testset "Empty column" begin
     for T in COEFF_TYPES
-        @testset "$T" begin emtpy_column_tests(T) end
+        @testset "$T" begin empty_column_tests(T) end
     end
 end


### PR DESCRIPTION
This is mostly straightforward.

One open question: how should we handle unbounded columns with close-to-zero objective?
For instance: if a problem has an empty column with no lower bound and objective coeff of `1e-30`, should we declare it dual infeasible?

Since empty columns are just empty rows in the dual, I would suggest to follow the same idea: we use a dual feasibility tolerance `ϵ_d`, and declare dual infeasibility if column `j` is empty, has no lower (resp. upper) bound and its objective is greater (resp. smaller) than `ϵ_d` (resp. `-ϵ_d`).

Obviously, using a "dual feasibility" tolerance for MIPs could raise some eyebrows.


