### PR TITLE
Compat entries for julia, MOI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,5 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
+MathOptInterface = "~0.9.20"
 julia = "1.5"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,4 +5,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MathOptInterface = "~0.9.20"
-julia = "1"
+julia = "1.5"


### PR DESCRIPTION
We were missing the compat entries in `/Project.toml` (after a few minutes I realized the previous compat bound for MOI was in `test/Project.toml`).

I have also bumped the Julia compat entry to `1.5`. This is because I used `Base.@kwdef` in `src/options.jl`, which requires Julia 1.1+ (so I bumped the requirement to the stable version).
Let me know if that's an issue.